### PR TITLE
Refactor: Replace install/update alerts with a welcome page

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -21,6 +21,9 @@
                 <div class="sidebar-sticky">
                     <ul class="nav flex-column">
                         <li class="nav-item">
+                            <a class="nav-link" href="welcome.html">Welcome</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link active" href="#">Settings</a>
                         </li>
                         <li class="nav-item">

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,7 +1,10 @@
 
 <html>
-    <body style="width: 400px">
-      <p>Please ignore - this is the result of the mandatory Chrome extension manifest v3 changes and you should only be seeing this because of the modal dialog when first activated after a new installation or extension version update.
+    <head>
+        <link rel="stylesheet" href="style.css"/>
+    </head>
+    <body style="width: 200px; text-align: center;">
+      <p>Sorting tabs...</p>
       <script src="./popup.js"></script>
     </body>
 </html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,39 +1,12 @@
-const thisVersion = chrome.runtime.getManifest().version;
-var newInstallOrUpdate = false;
-
-// Clear install & upgrade flags once they've been handled...
-function clearInstallOrUpdate() {
-    chrome.storage.sync.set({
-        installedVersion: chrome.runtime.getManifest().version,
-        newInstall: false,
-        newUpdate: false
-    }, function () {});
-}
-
-// Display modal dialog when first clicked after an install or update...
+// Display welcome page when first clicked after an install or update...
 chrome.storage.sync.get({
     installedVersion: '',
     newInstall: false,
     newUpdate: false,
 }, function (config) {
-    clearInstallOrUpdate();
-    if (config.newInstall) {
-        alert(`Welcome to Super Tab Sorter!
-
-        Please review the "User Guide" before getting started.
-
-        You'll need to click the extension icon, again, to sort your tabs after dismissing this dialog but you won't see this dialog again unless you reinstall this extension.
-
-        You can right-click on the extension icon and select \"Options\" at any time to configure extension settings and review the user guide.`);
-        window.open(chrome.runtime.getURL('./userguide.html'));
-    } else if (config.newUpdate) {
-        alert("Super Tab Sorter has been updated to v" + thisVersion +
-        ".\n\nThis version uses the new Chrome manifest v3 API (major architectural change) and adds direct support for Chrome's tab groups feature" +
-        ".\n\nIt also adds optional duplicate tab removal (during sorting) and Sort By URL sorts by root domain and sub-sorts by host name." +
-        "\n\nPlease review the updated User Guide to learn more about the latest changes." +
-        "\n\nYou'll need to click the extension icon, again, to sort your tabs after dismissing this dialog but you won't see this dialog again until installing the next update." +
-        "\n\nYou can right-click on the extension icon and select \"Options\" at any time to configure extension settings and review the user guide.");
-        window.open(chrome.runtime.getURL('./userguide.html'));
+    if (config.newInstall || config.newUpdate) {
+        chrome.tabs.create({ url: chrome.runtime.getURL('welcome.html') });
+        window.close();
     } else {
         // Send click event to background.js for processing...
         chrome.runtime.sendMessage({
@@ -42,6 +15,6 @@ chrome.storage.sync.get({
             if (response.message === 'success') {
                 window.close();
             }
-            });
-            }
+        });
+    }
 });

--- a/src/userguide.html
+++ b/src/userguide.html
@@ -21,6 +21,9 @@
                 <div class="sidebar-sticky">
                     <ul class="nav flex-column">
                         <li class="nav-item">
+                            <a class="nav-link" href="welcome.html">Welcome</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link" href="options.html">Settings</a>
                         </li>
                         <li class="nav-item">

--- a/src/welcome.html
+++ b/src/welcome.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="author" content="Peter White">
+    <title>Super Tab Sorter: Welcome</title>
+
+    <!-- Bootstrap core CSS -->
+    <link rel="stylesheet" href="bootstrap.min.css"/>
+    <link rel="stylesheet" href="style.css"/>
+</head>
+
+<body>
+    <div class="container bg-light">
+        <h3 class="navbar-brand h3">Super Tab Sorter</h3>
+    </div>
+    <div class="container">
+        <div class="row">
+            <nav class="col-md-2 d-none d-md-block bg-light sidebar">
+                <div class="sidebar-sticky">
+                    <ul class="nav flex-column">
+                        <li class="nav-item">
+                            <a class="nav-link" href="options.html">Settings</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="userguide.html">User Guide</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="about.html">About</a>
+                        </li>
+                    </ul>
+                </div>
+            </nav>
+
+            <main role="main" class="col-md-9 ml-sm-auto col-lg-10 px-4">
+                <div id="welcome-message" class="d-none">
+                    <h3>Welcome to Super Tab Sorter!</h3>
+                    <p>Please review the <a href="userguide.html">User Guide</a> before getting started.</p>
+                    <p>You can right-click on the extension icon and select "Options" at any time to configure extension settings and review the user guide.</p>
+                </div>
+                <div id="update-message" class="d-none">
+                    <h3>Super Tab Sorter has been updated to v<span id="version"></span>!</h3>
+                    <p>This version uses the new Chrome manifest v3 API (major architectural change) and adds direct support for Chrome's tab groups feature.</p>
+                    <p>It also adds optional duplicate tab removal (during sorting) and Sort By URL sorts by root domain and sub-sorts by host name.</p>
+                    <p>Please review the updated <a href="userguide.html">User Guide</a> to learn more about the latest changes.</p>
+                </div>
+            </main>
+        </div>
+    </div>
+    <script src="jquery-3.7.1.slim.min.js"></script>
+    <script src="bootstrap.min.js"></script>
+    <script src="welcome.js"></script>
+</body>
+
+</html>

--- a/src/welcome.js
+++ b/src/welcome.js
@@ -1,0 +1,26 @@
+const thisVersion = chrome.runtime.getManifest().version;
+
+function clearInstallOrUpdate() {
+    chrome.storage.sync.set({
+        newInstall: false,
+        newUpdate: false,
+    }, function () {});
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    document.getElementById('version').textContent = thisVersion;
+    chrome.storage.sync.get({
+        newInstall: false,
+        newUpdate: false,
+    }, function (config) {
+        if (config.newInstall) {
+            document.getElementById('welcome-message').classList.remove('d-none');
+        } else if (config.newUpdate) {
+            document.getElementById('update-message').classList.remove('d-none');
+        }
+
+        if (config.newInstall || config.newUpdate) {
+            clearInstallOrUpdate();
+        }
+    });
+});


### PR DESCRIPTION
I replaced the disruptive `alert()` dialogs on new installs and updates with a dedicated `welcome.html` page that opens in a new tab. This provides a cleaner and more friendly experience for you.

- I created `welcome.html` and `welcome.js` to handle the new user flow.
- I modified `popup.js` to open the welcome page instead of showing alerts.
- I updated `popup.html` with a more appropriate message.
- I added navigation links to the new welcome page in `options.html` and `userguide.html`.